### PR TITLE
Add AGENTS.md for development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Jekyll-based personal tech blog using the Minimal Mistakes theme (v4.26.2).
+
+### Services
+
+| Service | Command | Notes |
+|---------|---------|-------|
+| Jekyll dev server | `bundle exec jekyll serve --host 0.0.0.0 --port 4000` | Main dev server, site at http://localhost:4000/ |
+
+### Key commands
+
+- **Build site**: `bundle exec jekyll build`
+- **Serve locally**: `bundle exec jekyll serve --host 0.0.0.0 --port 4000`
+- **Minify JS** (only if editing JS files): `npm install && bundle exec rake js`
+
+### Non-obvious caveats
+
+- Ruby gems are installed to `vendor/bundle` (local path) via `bundle config set --local path 'vendor/bundle'`. This avoids permission issues with the system gem directory.
+- The Sass deprecation warnings during build are expected and come from the upstream Minimal Mistakes theme's Susy grid vendor code — they do not affect functionality.
+- There is no Gemfile.lock committed — `bundle install` resolves dependencies fresh each time.
+- The `docs/` and `test/` directories are from the upstream Minimal Mistakes theme and are excluded from the Jekyll build via `_config.yml`.
+- Blog content is in `_posts/` (Korean-language posts on security, databases, Python, etc.).
+- No linter is configured in this project. The main quality check is `bundle exec jekyll build` succeeding without errors.
+- No automated test suite exists. Validation is done via successful site build and manual inspection.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minimal-mistakes",
-  "version": "4.26.1",
+  "version": "4.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minimal-mistakes",
-      "version": "4.26.1",
+      "version": "4.26.2",
       "license": "MIT",
       "devDependencies": {
         "uglify-js": "^3.17.4"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `AGENTS.md` with Cursor Cloud-specific development instructions for this Jekyll blog.

## Context

This PR adds development environment documentation so future cloud agents can quickly set up and serve the site locally.

### What's included:
- Service table (Jekyll dev server command)
- Key commands for build/serve/JS minification
- Non-obvious caveats (vendor/bundle path, Sass warnings, no Gemfile.lock, excluded dirs)

### Development Environment Setup:
- **Ruby 3.2** + Bundler for Jekyll
- **Node.js** + npm for JS minification (optional)
- Site served at http://localhost:4000/ via `bundle exec jekyll serve`

### Demo

[jekyll_blog_hello_world_demo.mp4](https://cursor.com/agents/bc-7b8fee3a-0e3b-462a-beeb-73863a8b6c48/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjekyll_blog_hello_world_demo.mp4)

[Blog homepage with dark theme](https://cursor.com/agents/bc-7b8fee3a-0e3b-462a-beeb-73863a8b6c48/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_dark_theme.webp)
[Blog post content rendering](https://cursor.com/agents/bc-7b8fee3a-0e3b-462a-beeb-73863a8b6c48/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_post_content.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b8fee3a-0e3b-462a-beeb-73863a8b6c48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b8fee3a-0e3b-462a-beeb-73863a8b6c48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

