### PR TITLE
fix(home): 홈 리스트 excerpt 공지 반복 제거

### DIFF
--- a/_includes/archive-single-home.html
+++ b/_includes/archive-single-home.html
@@ -1,0 +1,33 @@
+{% if post.header.teaser %}
+  {% capture teaser %}{{ post.header.teaser }}{% endcapture %}
+{% else %}
+  {% assign teaser = site.teaser %}
+{% endif %}
+
+{% if post.id %}
+  {% assign title = post.title | markdownify | remove: "<p>" | remove: "</p>" %}
+{% else %}
+  {% assign title = post.title %}
+{% endif %}
+
+<div class="{{ include.type | default: 'list' }}__item">
+  <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork"{% if post.locale %} lang="{{ post.locale }}"{% endif %}>
+    {% if include.type == "grid" and teaser %}
+      <div class="archive__item-teaser">
+        <img src="{{ teaser | relative_url }}" alt="">
+      </div>
+    {% endif %}
+    <h2 class="archive__item-title no_toc" itemprop="headline">
+      {% if post.link %}
+        <a href="{{ post.link }}">{{ title }}</a> <a href="{{ post.url | relative_url }}" rel="permalink"><i class="fas fa-link" aria-hidden="true" title="permalink"></i><span class="sr-only">Permalink</span></a>
+      {% else %}
+        <a href="{{ post.url | relative_url }}" rel="permalink">{{ title }}</a>
+      {% endif %}
+    </h2>
+    {% include page__meta.html type=include.type %}
+    {% include home-excerpt.html %}
+    {% if home_excerpt != "" %}
+      <p class="archive__item-excerpt archive__item-excerpt--home" itemprop="description">{{ home_excerpt | truncate: 160 }}</p>
+    {% endif %}
+  </article>
+</div>

--- a/_includes/documents-collection.html
+++ b/_includes/documents-collection.html
@@ -9,5 +9,9 @@
 {% endif %}
 
 {%- for post in entries -%}
-  {% include archive-single.html type=include.type %}
+  {% if include.variant == 'home' %}
+    {% include archive-single-home.html type=include.type %}
+  {% else %}
+    {% include archive-single.html type=include.type %}
+  {% endif %}
 {%- endfor -%}

--- a/_includes/home-excerpt.html
+++ b/_includes/home-excerpt.html
@@ -1,0 +1,49 @@
+{% comment %}
+  Home list excerpt: skip site-wide notice boilerplate, use first substantive body text.
+  Output: assign `home_excerpt` (plain text, may be empty).
+{% endcomment %}
+{% assign home_excerpt = "" %}
+{% assign raw_excerpt = post.excerpt | markdownify | strip_html | strip | replace: "  ", " " %}
+{% assign is_notice_boilerplate = false %}
+
+{% if raw_excerpt contains "교육 목적으로만 제공" or raw_excerpt contains "[공지사항]" %}
+  {% assign is_notice_boilerplate = true %}
+{% endif %}
+
+{% unless is_notice_boilerplate %}
+  {% assign home_excerpt = raw_excerpt %}
+{% else %}
+  {% assign sections = post.content | split: "## " %}
+  {% if sections.size > 1 %}
+    {% assign body_chunk = sections[1] %}
+    {% assign body_lines = body_chunk | split: "
+" %}
+    {% for line in body_lines %}
+      {% assign paragraph = line | strip %}
+      {% if paragraph == "" %}
+        {% continue %}
+      {% endif %}
+      {% if paragraph contains "#" %}
+        {% continue %}
+      {% endif %}
+      {% if paragraph contains "![" %}
+        {% continue %}
+      {% endif %}
+      {% if paragraph contains "<" %}
+        {% continue %}
+      {% endif %}
+      {% if paragraph contains "{:" %}
+        {% continue %}
+      {% endif %}
+      {% if paragraph contains "**[" %}
+        {% continue %}
+      {% endif %}
+      {% assign candidate = paragraph | markdownify | strip_html | strip | replace: "  ", " " %}
+      {% if candidate.size < 24 %}
+        {% continue %}
+      {% endif %}
+      {% assign home_excerpt = candidate %}
+      {% break %}
+    {% endfor %}
+  {% endif %}
+{% endunless %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -16,7 +16,7 @@ layout: archive
 
 {% assign entries_layout = page.entries_layout | default: 'list' %}
 <div class="entries-{{ entries_layout }}">
-  {% include documents-collection.html entries=posts type=entries_layout %}
+  {% include documents-collection.html entries=posts type=entries_layout variant='home' %}
 </div>
 
 {% include paginator.html %}

--- a/_sass/_weo0o0-overrides.scss
+++ b/_sass/_weo0o0-overrides.scss
@@ -197,3 +197,11 @@ html {
     width: 100%;
   }
 }
+
+.layout--home .archive__item-excerpt--home {
+  margin-top: 0.35rem;
+  color: var(--note-subtext);
+  font-family: var(--note-font-body);
+  line-height: 1.65;
+  text-wrap: pretty;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes P0 home list issue where every post excerpt showed the identical legal notice.

## Approach (Option A)

- `_includes/home-excerpt.html` — detects notice boilerplate, falls back to first substantive paragraph after the first `##` heading
- `_includes/archive-single-home.html` — home-only archive card using the smart excerpt
- `_layouts/home.html` — passes `variant='home'` to the collection include
- `_includes/documents-collection.html` — routes home variant to the new include
- `_sass/_weo0o0-overrides.scss` — subtle home excerpt typography

## Scope

- Home list only (archives unchanged)
- No theme core edits; post body notices preserved on single pages

## Verify

```bash
bundle exec jekyll serve
# Home recent posts should show unique excerpts (e.g. SQLi intro paragraph)
npm run pa11y:home
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01d59-2e8e-7d6a-98ee-354d444dfc0c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01d59-2e8e-7d6a-98ee-354d444dfc0c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

