### PR TITLE
fix(home): 홈·아카이브 author sidebar 제거, 글 페이지만 노출

### DIFF
--- a/_pages/category-archive.md
+++ b/_pages/category-archive.md
@@ -2,6 +2,6 @@
 title: "카테고리"
 layout: categories
 permalink: /categories/
-author_profile: true
+author_profile: false
 sidebar_main: true
 ---

--- a/_pages/tag-archive.md
+++ b/_pages/tag-archive.md
@@ -2,6 +2,6 @@
 title: "태그"
 layout: tags
 permalink: /tags/
-author_profile: true
+author_profile: false
 sidebar_main: true
 ---

--- a/_pages/year-archive.md
+++ b/_pages/year-archive.md
@@ -2,5 +2,5 @@
 title: "연도"
 permalink: /year-archive/
 layout: posts
-author_profile: true
+author_profile: false
 ---

--- a/_posts/2024-03-24-frist.md
+++ b/_posts/2024-03-24-frist.md
@@ -4,7 +4,6 @@ title:  "첫 포스팅"
 categories: coding
 tag: [python, blog]
 toc: true
-author_profile: false
 sidebar:
     nav: "docs"
 published: true

--- a/_posts/2024-06-24-notice.md
+++ b/_posts/2024-06-24-notice.md
@@ -3,7 +3,6 @@ layout: single
 title:  "공지사항"
 categories: notice
 tag: [모의해킹, 해킹, 주의사항]
-author_profile: false
 ---
 
 # ☠️해킹 시도에 대한 법적, 윤리적 책임

--- a/_posts/2024-06-25-bee-box-Keyboard-settings.md
+++ b/_posts/2024-06-25-bee-box-Keyboard-settings.md
@@ -4,7 +4,6 @@ title:  "bee-box 키보드 설정방법"
 categories: bee-box
 tag: [bee-box, 설정]
 toc: true
-author_profile: false
 sidebar:
     nav: "docs"
 ---

--- a/_posts/2024-06-26-bee-box.md
+++ b/_posts/2024-06-26-bee-box.md
@@ -4,7 +4,6 @@ title: "bee-box란?"
 categories: bee-box
 tag: [bee-box, 이론]
 toc: true
-author_profile: false
 ---
 **[공지사항]** [본 블로그에 포함된 모든 정보는 교육 목적으로만 제공됩니다.](https://weo0o0.github.io/notice/notice/)
 {: .notice--danger}

--- a/_posts/2024-06-27-SQLi-splmap01.md
+++ b/_posts/2024-06-27-SQLi-splmap01.md
@@ -4,7 +4,6 @@ title:  "SQLi-sqlmap이란? "
 categories: SQLi
 tag: [SQLi, sqlmap, 이론]
 toc: true
-author_profile: false
 
 ---
 

--- a/_posts/2024-06-27-SQLi-sqlmap-otion-01.md
+++ b/_posts/2024-06-27-SQLi-sqlmap-otion-01.md
@@ -4,7 +4,6 @@ title:  "SQLi-sqlma 옵션 리스트 01"
 categories: SQLi
 tag: [SQLi, sqlmap, 이론, 옵션]
 toc: true
-author_profile: false
 
 ---
 

--- a/_posts/2024-06-27-SQLi-sqlmap.md
+++ b/_posts/2024-06-27-SQLi-sqlmap.md
@@ -4,7 +4,6 @@ title:  "SQLi-sqlmap-03"
 categories: coding
 tag: [python, blog]
 toc: true
-author_profile: false
 published: false
 ---
 

--- a/_posts/2024-06-27-db-Administrator-role.md
+++ b/_posts/2024-06-27-db-Administrator-role.md
@@ -4,7 +4,6 @@ title:  "데이터베이스 관리자 역활"
 categories: Database
 tag: [데이터베이스, 관리자 권한, 이론]
 toc: true
-author_profile: false
 published: true
 ---
 **[공지사항]** [본 블로그에 포함된 모든 정보는 교육 목적으로만 제공됩니다.](https://weo0o0.github.io/notice/notice/)

--- a/_posts/2024-06-28-Database-with-SQL-query.md
+++ b/_posts/2024-06-28-Database-with-SQL-query.md
@@ -4,7 +4,6 @@ title:  "데이터베이스 설계 및 SQL쿼리"
 categories: Database SQL
 tag: [SQL, 데이터베이스,이론]
 toc: true
-author_profile: false
 ---
 
 **[공지사항]** [본 블로그에 포함된 모든 정보는 교육 목적으로만 제공됩니다.](https://weo0o0.github.io/notice/notice/)

--- a/_posts/2024-06-28-SQLi-basic.md
+++ b/_posts/2024-06-28-SQLi-basic.md
@@ -4,7 +4,6 @@ title:  "SQLi란?"
 categories: SQLi
 tag: [SQLi, 이론, 옵션]
 toc: true
-author_profile: false
 ---
 
 **[공지사항]** [본 블로그에 포함된 모든 정보는 교육 목적으로만 제공됩니다.](https://weo0o0.github.io/notice/notice/)

--- a/_posts/2024-06-29-SQLi-sqlmap-otion-02.md
+++ b/_posts/2024-06-29-SQLi-sqlmap-otion-02.md
@@ -4,7 +4,6 @@ title:  "SQLi-sqlma 옵션 리스트 02"
 categories: SQLi
 tag: [SQLi, sqlmap, 이론, 옵션]
 toc: true
-author_profile: false
 ---
 
 **[공지사항]** [본 블로그에 포함된 모든 정보는 교육 목적으로만 제공됩니다.](https://weo0o0.github.io/notice/notice/)

--- a/_posts/2024-06-29-SQLi-sqlmap-otion-03.md
+++ b/_posts/2024-06-29-SQLi-sqlmap-otion-03.md
@@ -4,7 +4,6 @@ title:  "SQLi-sqlma 옵션 리스트 03"
 categories: SQLi
 tag: [SQLi, sqlmap, 이론, 옵션]
 toc: true
-author_profile: false
 ---
 
 **[공지사항]** [본 블로그에 포함된 모든 정보는 교육 목적으로만 제공됩니다.](https://weo0o0.github.io/notice/notice/)

--- a/_posts/2024-06-30-Digital-Logic.md
+++ b/_posts/2024-06-30-Digital-Logic.md
@@ -4,7 +4,6 @@ title:  "디지털 논리"
 categories: Digital-Logic
 tag: [디지털 논리, 이론]
 toc: true
-author_profile: false
 ---
 **[공지사항]** [본 블로그에 포함된 모든 정보는 교육 목적으로만 제공됩니다.](https://weo0o0.github.io/notice/notice/)
 {: .notice--danger}

--- a/_posts/2024-06-30-Permissions-Credentials.md
+++ b/_posts/2024-06-30-Permissions-Credentials.md
@@ -5,7 +5,6 @@ title: "해커관점에서 본 권한과 자격"
 categories: etc
 tag: [이론, 권한, 자격]
 toc: true
-author_profile: false
 
 ---
 

--- a/_posts/2024-07-09-Storm-Breaker.md
+++ b/_posts/2024-07-09-Storm-Breaker.md
@@ -4,7 +4,6 @@ title: "소셜 엔지니어링 Storm-Beaker"
 categories: social-engineering
 tag: [실습, 소셜 엔지니어링, 정보 수집]
 toc: true
-author_profile: false
 ---
 **[공지사항]** [본 블로그에 포함된 모든 정보는 교육 목적으로만 제공됩니다.](https://weo0o0.github.io/notice/notice/)
 {: .notice--danger}

--- a/_posts/2024-07-30-Types-of-Permissions.md
+++ b/_posts/2024-07-30-Types-of-Permissions.md
@@ -4,7 +4,6 @@ title: "관리자 권한의 종류와 시스템 권한"
 categories: etc
 tag: [이론, 권한]
 toc: true
-author_profile: false
 ---
 
 **[공지사항]** [본 블로그에 포함된 모든 정보는 교육 목적으로만 제공됩니다.](https://weo0o0.github.io/notice/notice/)

--- a/_sass/_weo0o0-overrides.scss
+++ b/_sass/_weo0o0-overrides.scss
@@ -205,3 +205,11 @@ html {
   line-height: 1.65;
   text-wrap: pretty;
 }
+
+/* Home — full-width content when author sidebar is off */
+.layout--home #main .archive {
+  float: none;
+  width: 100%;
+  max-width: 100%;
+  padding-inline-end: 0;
+}

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: home
-author_profile: true
+author_profile: false
 hero:
   headline: "밤에 읽히는 시스템 노트"
   support: "권한·네트워크·보안을 한 편씩 정리한 개인 노트입니다."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

/impeccable P1 author sidebar critique에 따라 **옵션 A** 두 가지를 모두 적용했습니다.

1. **수정 방식 A** — 홈에서 `author_profile: false` + full-width archive 스타일
2. **Author 노출 A** — 단일 글 페이지 + 푸터 소셜 링크만 (홈·아카이브는 sidebar 없음)

## Changes

- `index.html`: `author_profile: false`
- `_pages/year-archive.md`, `category-archive.md`, `tag-archive.md`: `author_profile: false`
- `_posts/*.md` (16개): 개별 `author_profile: false` 제거 → `_config.yml` 기본값 `true` 상속
- `_sass/_weo0o0-overrides.scss`: sidebar 없을 때 홈 archive full-width

## Expected behavior

| 페이지 | Author sidebar |
|--------|----------------|
| 홈 | ❌ |
| 연/카테고리/태그 아카이브 | ❌ |
| 단일 글 | ✅ |
| 푸터 소셜 | ✅ (기존 유지) |

## Verification

- [ ] 홈: hero → full-width 글 목록, sidebar 없음
- [ ] 모바일: author 블록이 hero 위에 먼저 나오지 않음
- [ ] 단일 글: author sidebar 정상 표시
- [ ] 아카이브: sidebar 없음
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01d59-2e8e-7d6a-98ee-354d444dfc0c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01d59-2e8e-7d6a-98ee-354d444dfc0c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

