### PR TITLE
fix(i18n): P2 한국어 UI 카피·ko-KR 날짜 형식

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ minimal_mistakes_skin    : "dark" # "air", "aqua", "contrast", "dark", "dirt", "
 
 # Site Settings
 locale                   : "ko-KR"
+date_format              : "%Y년 %-m월 %-d일"
 rtl                      : # true, false (default) # turns direction of the page into right to left for RTL languages
 title                    : "Weo0o0-Note"
 title_separator          : "|"
@@ -115,7 +116,7 @@ analytics:
 author:
   name             : "Weo0o0-Note"
   avatar           : "assets/images/logo.jpg"
-  bio              : "방갑습니다🤗"
+  bio              : "반갑습니다🤗"
   location         : "Daejeon, South Korea"
   email            : #
   links:
@@ -315,7 +316,7 @@ defaults:
       share: true
       related: true
       show_date: true
-      date_format: "%Y-%m-%d"
+      date_format: "%Y년 %-m월 %-d일"
       toc: true
       toc_sticky: true
       toc_label: 목차

--- a/_data/ui-text.yml
+++ b/_data/ui-text.yml
@@ -594,18 +594,18 @@ ne-NP:
 # Korean
 # ------
 ko: &DEFAULT_KO
-  skip_links                 :
-  skip_primary_nav           :
-  skip_content               :
-  skip_footer                :
+  skip_links                 : "건너뛰기 링크"
+  skip_primary_nav           : "주 메뉴로 건너뛰기"
+  skip_content               : "본문으로 건너뛰기"
+  skip_footer                : "푸터로 건너뛰기"
   page                       : "페이지"
   pagination_previous        : "이전"
   pagination_next            : "다음"
-  breadcrumb_home_label      : "Home"
+  breadcrumb_home_label      : "홈"
   breadcrumb_separator       : "/"
   menu_label                 : "토글 메뉴"
-  search_label               :
-  toc_label                  : "On This Page"
+  search_label               : "검색 열기"
+  toc_label                  : "목차"
   ext_link_label             : "직접 링크"
   less_than                  : "최대"
   minute_read                : "분 소요"

--- a/_includes/page__meta.html
+++ b/_includes/page__meta.html
@@ -5,7 +5,7 @@
       {% assign date = document.date %}
       <span class="page__meta-date">
         <i class="far {% if include.type == 'grid' and document.read_time and document.show_date %}fa-fw {% endif %}fa-calendar-alt" aria-hidden="true"></i>
-        {% assign date_format = site.date_format | default: "%B %-d, %Y" %}
+        {% assign date_format = document.date_format | default: site.date_format | default: "%Y년 %-m월 %-d일" %}
         <time datetime="{{ date | date_to_xmlschema }}">{{ date | date: date_format }}</time>
       </span>
     {% endif %}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PRD **Now P2** — 홈·공통 UI 텍스트 로케일만 시공합니다. 레이아웃·hero·author sidebar는 변경 없습니다.

## Changes

| 파일 | 내용 |
|------|------|
| `_data/ui-text.yml` (ko) | skip 링크 4종, `breadcrumb_home_label`, `toc_label`, `search_label` 한글화 |
| `_config.yml` | bio `방갑습니다` → `반갑습니다`; 사이트·posts `date_format: "%Y년 %-m월 %-d일"` |
| `_includes/page__meta.html` | `document.date_format` → `site.date_format` 순으로 읽어 홈·리스트 날짜 통일 |

## Design decisions

- 기존 Mocha / teal / Gowun 톤 유지 — **카피·날짜만**
- 날짜: EN `%B %-d, %Y` 폴백 제거 → ko-KR `2024년 6월 24일` 형식

## Out of scope

- hero / author sidebar / archives 레이아웃
- `search:` ON (Later B)
- pa11y 실행·수정 (다음 턴)

## Verify

배포 후:

- [ ] Tab으로 skip 링크가 한글
- [ ] breadcrumb 첫 칸 `홈`, TOC `목차`, 검색 토글 `검색 열기`
- [ ] 글 sidebar bio `반갑습니다`
- [ ] 홈 리스트·글 메타 날짜가 `YYYY년 M월 D일`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01d59-2e8e-7d6a-98ee-354d444dfc0c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01d59-2e8e-7d6a-98ee-354d444dfc0c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

