### PR TITLE
fix(archives): P1 scan density, headings, tag chrome

### DIFF
--- a/_includes/archive-single-home.html
+++ b/_includes/archive-single-home.html
@@ -17,13 +17,13 @@
         <img src="{{ teaser | relative_url }}" alt="">
       </div>
     {% endif %}
-    <h2 class="archive__item-title no_toc" itemprop="headline">
+    <h3 class="archive__item-title no_toc" itemprop="headline">
       {% if post.link %}
         <a href="{{ post.link }}">{{ title }}</a> <a href="{{ post.url | relative_url }}" rel="permalink"><i class="fas fa-link" aria-hidden="true"></i><span class="sr-only">{{ site.data.ui-text[site.locale].permalink_label | default: "고유 링크" }}</span></a>
       {% else %}
         <a href="{{ post.url | relative_url }}" rel="permalink">{{ title }}</a>
       {% endif %}
-    </h2>
+    </h3>
     {% include page__meta.html type=include.type %}
     {% include home-excerpt.html %}
     {% if home_excerpt != "" %}

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -10,24 +10,29 @@
   {% assign title = post.title %}
 {% endif %}
 
+{% assign show_excerpt = include.show_excerpt | default: false %}
+{% assign excerpt_limit = include.excerpt_limit | default: 160 %}
+
 <div class="{{ include.type | default: 'list' }}__item">
-  <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork"{% if post.locale %} lang="{{ post.locale }}"{% endif %}>
+  <article class="archive__item{% unless show_excerpt %} archive__item--compact{% endunless %}" itemscope itemtype="https://schema.org/CreativeWork"{% if post.locale %} lang="{{ post.locale }}"{% endif %}>
     {% if include.type == "grid" and teaser %}
       <div class="archive__item-teaser">
         <img src="{{ teaser | relative_url }}" alt="">
       </div>
     {% endif %}
-    <h2 class="archive__item-title no_toc" itemprop="headline">
+    <h3 class="archive__item-title no_toc" itemprop="headline">
       {% if post.link %}
         <a href="{{ post.link }}">{{ title }}</a> <a href="{{ post.url | relative_url }}" rel="permalink"><i class="fas fa-link" aria-hidden="true"></i><span class="sr-only">{{ site.data.ui-text[site.locale].permalink_label | default: "고유 링크" }}</span></a>
       {% else %}
         <a href="{{ post.url | relative_url }}" rel="permalink">{{ title }}</a>
       {% endif %}
-    </h2>
+    </h3>
     {% include page__meta.html type=include.type %}
-    {% include home-excerpt.html %}
-    {% if home_excerpt != "" %}
-      <p class="archive__item-excerpt archive__item-excerpt--smart" itemprop="description">{{ home_excerpt | truncate: 160 }}</p>
+    {% if show_excerpt %}
+      {% include home-excerpt.html %}
+      {% if home_excerpt != "" %}
+        <p class="archive__item-excerpt archive__item-excerpt--smart" itemprop="description">{{ home_excerpt | truncate: excerpt_limit }}</p>
+      {% endif %}
     {% endif %}
   </article>
 </div>

--- a/_includes/posts-taxonomy.html
+++ b/_includes/posts-taxonomy.html
@@ -5,21 +5,29 @@
   {% endif %}
 {% endfor %}
 
-<ul class="taxonomy__index">
-  {% for i in (1..items_max) reversed %}
-    {% for item in include.taxonomies %}
-      {% if item[1].size == i %}
-        <li>
-          <a href="#{{ item[0] | slugify }}">
-            <strong>{{ item[0] }}</strong> <span class="taxonomy__count">{{ i }}</span>
-          </a>
-        </li>
-      {% endif %}
-    {% endfor %}
-  {% endfor %}
-</ul>
-
 {% assign entries_layout = page.entries_layout | default: 'list' %}
+{% assign show_excerpt = include.show_excerpt | default: false %}
+
+<nav class="taxonomy__index-wrap" aria-label="{{ include.index_label | default: '분류 바로가기' }}">
+  <ul class="taxonomy__index">
+    {% for i in (1..items_max) reversed %}
+      {% for item in include.taxonomies %}
+        {% if item[1].size == i %}
+          <li>
+            <a href="#{{ item[0] | slugify }}">
+              <strong>{{ item[0] }}</strong> <span class="taxonomy__count">{{ i }}</span>
+            </a>
+          </li>
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
+  </ul>
+</nav>
+
+{% if include.hint %}
+  <p class="taxonomy__hint">{{ include.hint }}</p>
+{% endif %}
+
 {% for i in (1..items_max) reversed %}
   {% for taxonomy in include.taxonomies %}
     {% if taxonomy[1].size == i %}
@@ -27,11 +35,14 @@
         <h2 class="archive__subtitle">{{ taxonomy[0] }}</h2>
         <div class="entries-{{ entries_layout }}">
           {% for post in taxonomy.last %}
-            {% include archive-single.html type=entries_layout %}
+            {% include archive-single.html type=entries_layout show_excerpt=show_excerpt %}
           {% endfor %}
         </div>
-        <a href="#page-title" class="back-to-top">{{ site.data.ui-text[site.locale].back_to_top | default: 'Back to Top' }} &uarr;</a>
       </section>
     {% endif %}
   {% endfor %}
 {% endfor %}
+
+<p class="archive-back">
+  <a href="#page-title" class="back-to-top">{{ site.data.ui-text[site.locale].back_to_top | default: 'Back to Top' }} &uarr;</a>
+</p>

--- a/_layouts/categories.html
+++ b/_layouts/categories.html
@@ -4,4 +4,9 @@ layout: archive
 
 {{ content }}
 
-{% include posts-taxonomy.html taxonomies=site.categories %}
+{% include posts-taxonomy.html
+  taxonomies=site.categories
+  show_excerpt=false
+  index_label="카테고리 바로가기"
+  hint="카테고리 칩으로 이동한 뒤, 제목과 날짜로 훑어보세요."
+%}

--- a/_layouts/posts.html
+++ b/_layouts/posts.html
@@ -4,27 +4,41 @@ layout: archive
 
 {{ content }}
 
-<ul class="taxonomy__index">
-  {% assign postsInYear = site.posts | where_exp: "item", "item.hidden != true" | group_by_exp: 'post', 'post.date | date: "%Y"' %}
-  {% for year in postsInYear %}
-    <li>
-      <a href="#{{ year.name }}">
-        <strong>{{ year.name }}</strong> <span class="taxonomy__count">{{ year.items | size }}</span>
-      </a>
-    </li>
-  {% endfor %}
-</ul>
-
+{% assign postsInYear = site.posts | where_exp: "item", "item.hidden != true" | group_by_exp: 'post', 'post.date | date: "%Y"' %}
 {% assign entries_layout = page.entries_layout | default: 'list' %}
-{% assign postsByYear = site.posts | where_exp: "item", "item.hidden != true" | group_by_exp: 'post', 'post.date | date: "%Y"' %}
-{% for year in postsByYear %}
+
+<nav class="taxonomy__index-wrap" aria-label="연도 바로가기">
+  <ul class="taxonomy__index">
+    {% for year in postsInYear %}
+      <li>
+        <a href="#{{ year.name }}">
+          <strong>{{ year.name }}</strong> <span class="taxonomy__count">{{ year.items | size }}</span>
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</nav>
+
+{% if postsInYear.size == 1 %}
+  {% assign only_year = postsInYear.first %}
+  <p class="taxonomy__hint">
+    {{ only_year.name }}년 글 {{ only_year.items | size }}편입니다. 아래 목록을 날짜·읽 시간으로 훑어 고르세요.
+  </p>
+{% elsif postsInYear.size > 1 %}
+  <p class="taxonomy__hint">연도 칩으로 구간을 이동한 뒤, 제목과 날짜로 훑어보세요.</p>
+{% endif %}
+
+{% for year in postsInYear %}
   <section id="{{ year.name }}" class="taxonomy__section">
     <h2 class="archive__subtitle">{{ year.name }}</h2>
     <div class="entries-{{ entries_layout }}">
       {% for post in year.items %}
-        {% include archive-single.html type=entries_layout %}
+        {% include archive-single.html type=entries_layout show_excerpt=false %}
       {% endfor %}
     </div>
-    <a href="#page-title" class="back-to-top">{{ site.data.ui-text[site.locale].back_to_top | default: 'Back to Top' }} &uarr;</a>
   </section>
 {% endfor %}
+
+<p class="archive-back">
+  <a href="#page-title" class="back-to-top">{{ site.data.ui-text[site.locale].back_to_top | default: 'Back to Top' }} &uarr;</a>
+</p>

--- a/_layouts/tags.html
+++ b/_layouts/tags.html
@@ -4,4 +4,9 @@ layout: archive
 
 {{ content }}
 
-{% include posts-taxonomy.html taxonomies=site.tags %}
+{% include posts-taxonomy.html
+  taxonomies=site.tags
+  show_excerpt=false
+  index_label="태그 바로가기"
+  hint="같은 글이 여러 태그에 나타날 수 있습니다. 위 칩으로 이동한 뒤 제목·날짜로 훑으세요."
+%}

--- a/_sass/_weo0o0-overrides.scss
+++ b/_sass/_weo0o0-overrides.scss
@@ -317,9 +317,28 @@ html {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin: 0 0 1.75rem;
+  margin: 0;
   padding: 0;
   list-style: none;
+}
+
+.layout--posts .taxonomy__index-wrap,
+.layout--categories .taxonomy__index-wrap,
+.layout--tags .taxonomy__index-wrap {
+  margin: 0 0 1rem;
+  padding: 0.85rem;
+  background-color: var(--note-mantle);
+  border: 1px solid var(--note-overlay);
+  border-radius: 8px;
+}
+
+/* Tags — sticky jump index so Kai can skim without per-section back-to-top */
+.layout--tags .taxonomy__index-wrap {
+  position: sticky;
+  top: 0.75rem;
+  z-index: 2;
+  margin-bottom: 1.25rem;
+  box-shadow: 0 8px 24px rgba(17, 17, 27, 0.35);
 }
 
 .layout--posts .taxonomy__index a,
@@ -372,14 +391,90 @@ html {
 .layout--posts .archive__subtitle,
 .layout--categories .archive__subtitle,
 .layout--tags .archive__subtitle {
-  margin: 0 0 1rem;
-  padding-bottom: 0.5rem;
+  margin: 1.75rem 0 0.55rem;
+  padding-bottom: 0.4rem;
   font-family: var(--note-font-body);
   font-size: clamp(1.15rem, 2.5vw, 1.35rem);
   font-weight: 700;
   color: var(--note-text);
-  border-bottom: 1px solid var(--note-overlay);
+  border-bottom: 1px solid rgba(0, 173, 181, 0.35);
   text-wrap: pretty;
+}
+
+.layout--posts .taxonomy__section:first-of-type .archive__subtitle,
+.layout--categories .taxonomy__section:first-of-type .archive__subtitle,
+.layout--tags .taxonomy__section:first-of-type .archive__subtitle {
+  margin-top: 1.1rem;
+}
+
+.taxonomy__hint {
+  margin: 0.35rem 0 0.25rem;
+  max-width: 38rem;
+  font-family: var(--note-font-ui);
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: var(--note-subtext);
+  text-wrap: pretty;
+}
+
+/* Single-year index: keep chip scannable even when alone */
+.layout--posts .taxonomy__index-wrap:has(.taxonomy__index li:only-child) .taxonomy__index a {
+  min-height: 3rem;
+  padding-inline: 1rem;
+  font-size: 1rem;
+}
+
+.layout--posts .taxonomy__index-wrap:has(.taxonomy__index li:only-child) .taxonomy__count {
+  font-size: 0.95rem;
+}
+
+.archive-back {
+  margin: 2rem 0 0;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(205, 214, 244, 0.12);
+  font-family: var(--note-font-ui);
+  font-size: 0.95rem;
+}
+
+.archive-back .back-to-top {
+  color: var(--note-accent);
+  text-decoration: none;
+}
+
+.archive-back .back-to-top:hover,
+.archive-back .back-to-top:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+/* Compact archive rows — title + date + read time as scan axis */
+.archive__item.archive__item--compact {
+  margin-bottom: 0;
+}
+
+.entries-list .list__item:has(.archive__item--compact) {
+  padding-top: 0.45rem;
+  padding-bottom: 0.45rem;
+}
+
+.archive__item.archive__item--compact .archive__item-title {
+  margin: 0 0 0.15rem;
+  font-size: clamp(1.05rem, 0.35vw + 1rem, 1.2rem);
+  line-height: 1.35;
+}
+
+.archive__item.archive__item--compact .page__meta {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.layout--tags .taxonomy__index-wrap {
+  max-height: min(40vh, 16rem);
+  overflow: auto;
+}
+
+.layout--tags .taxonomy__section {
+  margin-bottom: 0.35rem;
 }
 
 /* Primary button — white on teal fails AA; crust on accent ≈ 6.8:1 */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Archives **P1** from impeccable critique (P0 already in #21; **P2 excluded**).

1. **Row density** — archive lists are meta-first: `show_excerpt` defaults to `false`; compact rows emphasize title + date + read time (home still uses excerpts via `archive-single-home`).
2. **Heading hierarchy** — section labels are `h2`; post titles are `h3` in `archive-single` / posts / posts-taxonomy (and home list under its `h2`).
3. **Tags overcrowding** — removed per-section “맨 위로”; one page-level back-to-top; sticky tag index (+ scrollable when dense); hint that posts can appear under multiple tags (**posts not deleted**).
4. **Year index** — single-year hint copy + stronger chip/section rhythm when only one year exists.

## Files
- `_includes/archive-single.html`, `archive-single-home.html`, `posts-taxonomy.html`
- `_layouts/posts.html`, `tags.html`, `categories.html`
- `_sass/_weo0o0-overrides.scss` only (no `_sass/minimal-mistakes/`)

## Local verification (`bundle exec jekyll serve`)
| URL | Check |
| --- | --- |
| `/year-archive/` | compact rows, no excerpts, `h2`/`h3`, year hint (“2024년 글 15편…”), 1× back-to-top |
| `/categories/` | compact meta-first list, 1× back-to-top |
| `/tags/` | sticky index, 1× back-to-top only (no per-section), duplicate-list hint |

[Year archive P1](https://cursor.com/agents/bc-01a01d59-2e8e-7d6a-98ee-354d444dfc0c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fyear-archive-p1.png)
[Categories P1](https://cursor.com/agents/bc-01a01d59-2e8e-7d6a-98ee-354d444dfc0c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcategories-p1.png)
[Tags P1](https://cursor.com/agents/bc-01a01d59-2e8e-7d6a-98ee-354d444dfc0c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftags-p1.png)

## Test plan
- [x] Year / categories / tags HTML structure + visual spot-check locally
- [ ] Review on GH Pages after merge + `master:Weo0o0` sync

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01d59-2e8e-7d6a-98ee-354d444dfc0c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01d59-2e8e-7d6a-98ee-354d444dfc0c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

